### PR TITLE
refactor: 동적 임포트

### DIFF
--- a/apps/web/app/auction/[id]/edit/page.tsx
+++ b/apps/web/app/auction/[id]/edit/page.tsx
@@ -1,8 +1,19 @@
 import { Suspense } from 'react';
 
+import dynamic from 'next/dynamic';
+
 import ErrorBoundaryWrapper from '@/components/common/error-boundary-wrapper';
 
-import EditAuctionPage from '@/views/EditAuctionPage';
+const EditAuctionPage = dynamic(() => import('@/views/EditAuctionPage'), {
+  loading: () => (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+        <p className="text-gray-600">경매 수정 페이지를 불러오는 중...</p>
+      </div>
+    </div>
+  ),
+});
 
 const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
   const { id } = await params;

--- a/apps/web/app/auction/[id]/page.tsx
+++ b/apps/web/app/auction/[id]/page.tsx
@@ -1,7 +1,37 @@
-import { AuctionDetailContainer } from '@/components/auction-detail';
+import { Suspense } from 'react';
+
+import dynamic from 'next/dynamic';
+
+const AuctionDetailContainer = dynamic(
+  () =>
+    import('@/components/auction-detail').then((mod) => ({ default: mod.AuctionDetailContainer })),
+  {
+    loading: () => (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+          <p className="text-gray-600">경매 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    ),
+  }
+);
 
 const Page = () => {
-  return <AuctionDetailContainer />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+            <p className="text-gray-600">경매 정보를 불러오는 중...</p>
+          </div>
+        </div>
+      }
+    >
+      <AuctionDetailContainer />
+    </Suspense>
+  );
 };
 
 export default Page;

--- a/apps/web/app/auction/createAuction/page.tsx
+++ b/apps/web/app/auction/createAuction/page.tsx
@@ -1,7 +1,33 @@
-import CreateAuctionPage from '@/views/CreateAcutionPage';
+import { Suspense } from 'react';
+
+import dynamic from 'next/dynamic';
+
+const CreateAuctionPage = dynamic(() => import('@/views/CreateAcutionPage'), {
+  loading: () => (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+        <p className="text-gray-600">경매 등록 페이지를 불러오는 중...</p>
+      </div>
+    </div>
+  ),
+});
 
 const Page = () => {
-  return <CreateAuctionPage />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+            <p className="text-gray-600">경매 등록 페이지를 불러오는 중...</p>
+          </div>
+        </div>
+      }
+    >
+      <CreateAuctionPage />
+    </Suspense>
+  );
 };
 
 export default Page;

--- a/apps/web/app/auth/signup/page.tsx
+++ b/apps/web/app/auth/signup/page.tsx
@@ -1,10 +1,33 @@
 import { Suspense } from 'react';
 
-import { SignupFlow } from '@/components/auth/signup';
+import dynamic from 'next/dynamic';
+
+const SignupFlow = dynamic(
+  () => import('@/components/auth/signup').then((mod) => ({ default: mod.SignupFlow })),
+  {
+    loading: () => (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+          <p className="text-gray-600">회원가입 페이지를 불러오는 중...</p>
+        </div>
+      </div>
+    ),
+  }
+);
 
 const SignupPage = () => {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+            <p className="text-gray-600">회원가입 페이지를 불러오는 중...</p>
+          </div>
+        </div>
+      }
+    >
       <SignupFlow />
     </Suspense>
   );

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -1,7 +1,33 @@
-import SearchView from '@/components/search/search-view';
+import { Suspense } from 'react';
+
+import dynamic from 'next/dynamic';
+
+const SearchView = dynamic(() => import('@/components/search/search-view'), {
+  loading: () => (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+        <p className="text-gray-600">검색 페이지를 불러오는 중...</p>
+      </div>
+    </div>
+  ),
+});
 
 const Page = () => {
-  return <SearchView />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <div className="border-primary-500 mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2" />
+            <p className="text-gray-600">검색 페이지를 불러오는 중...</p>
+          </div>
+        </div>
+      }
+    >
+      <SearchView />
+    </Suspense>
+  );
 };
 
 export default Page;

--- a/apps/web/src/components/auction-detail/item-images.tsx
+++ b/apps/web/src/components/auction-detail/item-images.tsx
@@ -2,14 +2,34 @@
 
 import { useEffect, useState } from 'react';
 
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  type CarouselApi,
-} from '@/components/ui/carousel';
+const Carousel = dynamic(
+  () => import('@/components/ui/carousel').then((mod) => ({ default: mod.Carousel })),
+  {
+    loading: () => (
+      <div className="flex h-[400px] w-full items-center justify-center bg-gray-100">
+        <div className="text-center">
+          <div className="border-primary-500 mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"></div>
+          <p className="text-gray-600">이미지를 불러오는 중...</p>
+        </div>
+      </div>
+    ),
+  }
+);
+
+const CarouselContent = dynamic(
+  () => import('@/components/ui/carousel').then((mod) => ({ default: mod.CarouselContent })),
+  { ssr: false }
+);
+
+const CarouselItem = dynamic(
+  () => import('@/components/ui/carousel').then((mod) => ({ default: mod.CarouselItem })),
+  { ssr: false }
+);
+
+import type { CarouselApi } from '@/components/ui/carousel';
 
 interface ItemImagesProps {
   urls: string[];

--- a/apps/web/src/components/auth/signup/location-display.tsx
+++ b/apps/web/src/components/auth/signup/location-display.tsx
@@ -2,7 +2,25 @@
 
 import React, { useState, useEffect } from 'react';
 
-import { SignupKakaoMap } from '@/components/auth/signup';
+import dynamic from 'next/dynamic';
+
+const SignupKakaoMap = dynamic(
+  () => import('@/components/auth/signup').then((mod) => ({ default: mod.SignupKakaoMap })),
+  {
+    loading: () => (
+      <div
+        className="flex w-full items-center justify-center rounded-[10px] bg-white"
+        style={{ height: '130px' }}
+      >
+        <div className="text-center">
+          <div className="border-primary-500 mx-auto mb-2 h-6 w-6 animate-spin rounded-full border-2 border-t-transparent"></div>
+          <p className="text-sm text-neutral-600">지도를 불러오는 중...</p>
+        </div>
+      </div>
+    ),
+    ssr: false,
+  }
+);
 import { Button } from '@/components/ui/button';
 
 import { useGeolocation } from '@/hooks/common/useGeolocation';

--- a/apps/web/src/components/layout/navigation.tsx
+++ b/apps/web/src/components/layout/navigation.tsx
@@ -3,7 +3,12 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-import { HouseIcon, MessagesSquare, SearchIcon, UserRoundIcon } from 'lucide-react';
+import {
+  House as HouseIcon,
+  MessagesSquare,
+  Search as SearchIcon,
+  UserRound as UserRoundIcon,
+} from 'lucide-react';
 
 import { ROUTES, type NavMenuItem } from '@/lib/constants/routes';
 

--- a/apps/web/src/components/location/map-location-picker.tsx
+++ b/apps/web/src/components/location/map-location-picker.tsx
@@ -2,9 +2,20 @@
 
 import React, { useState, useEffect } from 'react';
 
+import dynamic from 'next/dynamic';
 import { X } from 'lucide-react';
 
-import KakaoMap from '@/components/location/kakao-map';
+const KakaoMap = dynamic(() => import('@/components/location/kakao-map'), {
+  loading: () => (
+    <div className="flex h-[400px] w-full items-center justify-center rounded-lg bg-gray-100">
+      <div className="text-center">
+        <div className="border-primary-500 mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"></div>
+        <p className="text-gray-600">지도를 불러오는 중...</p>
+      </div>
+    </div>
+  ),
+  ssr: false,
+});
 import SearchInput from '@/components/location/search-input';
 import { Button } from '@/components/ui/button';
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

  1. 페이지 레벨 다이나믹 임포트



  - /auction/[id] (8.64kB) → AuctionDetailContainer 다이나믹 임포트

  - /auth/signup (4.35kB) → SignupFlow 다이나믹 임포트

  - /auction/[id]/edit (2.73kB) → EditAuctionPage 다이나믹 임포트

  - /search (2.58kB) → SearchView 다이나믹 임포트

  - /auction/createAuction (2.49kB) → CreateAuctionPage 다이나믹 임포트



  2. Heavy 컴포넌트 다이나믹 임포트



  - Kakao Map 컴포넌트들: SignupKakaoMap, KakaoMap → SSR 비활성화 + 다이나믹 로딩

  - Carousel 컴포넌트: Carousel, CarouselContent, CarouselItem → 다이나믹 임포트



  3. lucide-react 아이콘 최적화



  - 이미 개별 import 사용 중 (트리 쉐이킹 최적화됨)

  - 61개 파일에서 개별적으로 필요한 아이콘만 임포트



## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
